### PR TITLE
Potential fix for code scanning alert no. 17: Bad HTML filtering regexp

### DIFF
--- a/webui/rproxy_core.js
+++ b/webui/rproxy_core.js
@@ -465,7 +465,7 @@
         const rewritten = scope.RProxy.rewriteCss(css, ctx, baseUrl);
         return match.replace(css, rewritten);
       });
-    out = out.replace(/<script\b([^>]*)>([\s\S]*?)<\/script\b[^>]*>/gi, (match, attrs, content) => {
+    out = out.replace(/<script\b([^>]*)>([\s\S]*?)<\/script\b[^<>]*>/gi, (match, attrs, content) => {
         const typeMatch = attrs.match(/\btype\s*=\s*(?:(['"])(.*?)\1|([^\s>]+))/i);
         const type = typeMatch ? (typeMatch[2] || typeMatch[3]).toLowerCase() : 'text/javascript';
         if (type === 'application/json' || type === 'application/ld+json' || type.indexOf('template') !== -1) {

--- a/webui/rproxy_core.js
+++ b/webui/rproxy_core.js
@@ -465,7 +465,7 @@
         const rewritten = scope.RProxy.rewriteCss(css, ctx, baseUrl);
         return match.replace(css, rewritten);
       });
-    out = out.replace(/<script\b([^>]*)>([\s\S]*?)<\/script>/gi, (match, attrs, content) => {
+    out = out.replace(/<script\b([^>]*)>([\s\S]*?)<\/script\b[^>]*>/gi, (match, attrs, content) => {
         const typeMatch = attrs.match(/\btype\s*=\s*(?:(['"])(.*?)\1|([^\s>]+))/i);
         const type = typeMatch ? (typeMatch[2] || typeMatch[3]).toLowerCase() : 'text/javascript';
         if (type === 'application/json' || type === 'application/ld+json' || type.indexOf('template') !== -1) {


### PR DESCRIPTION
Potential fix for [https://github.com/choury/sproxy/security/code-scanning/17](https://github.com/choury/sproxy/security/code-scanning/17)

General fix: make the script-block regex accept permissive HTML end-tag syntax used by browsers, specifically optional whitespace and optional extra invalid attributes before `>` in the closing `</script...>` tag.

Best targeted fix in `webui/rproxy_core.js` (around line 468): replace  
`/<script\b([^>]*)>([\s\S]*?)<\/script>/gi`  
with a safer pattern such as  
`/<script\b([^>]*)>([\s\S]*?)<\/script\b[^>]*>/gi`  
This keeps current behavior (capture attrs/content and rewrite JS content) while also matching malformed-but-browser-accepted end tags like `</script >` and `</script foo="bar">`.

No new imports or helper methods are required; only the regex literal in the existing `out.replace(...)` call needs updating.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
